### PR TITLE
Remove folding as a feature; VS Code supports folding by indent only

### DIFF
--- a/docs/feature_queue.org
+++ b/docs/feature_queue.org
@@ -9,7 +9,7 @@ The following is a rough list of features that may be implemented. It is meant a
 **** Fixed width
 ** Embedded images
 * Actions
-** Folding
+** Folding [tabled until later date: VS Code only supports folding by indentation]
 ** Promotion / demotion
 - I think I actually want to remove this
 - Or maybe consider subtree


### PR DESCRIPTION
Using indentation to cause folding would make the org file incompatible with other. (Tabled until later date or Microsoft update)