### PR TITLE
Feature/update action names with org prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,15 +25,15 @@
                 "title": "Org: Insert Subheading"
             },
             {
-                "command": "org.demoteLine",
+                "command": "org.doDemote",
                 "title": "Org: Do Demote"
             },
             {
-                "command": "org.promoteLine",
+                "command": "org.doPromote",
                 "title": "Org: Do Promote"
             },
             {
-                "command": "org.insertTimestamp",
+                "command": "org.timestamp",
                 "title": "Org: Timestamp"
             },
             {

--- a/package.json
+++ b/package.json
@@ -17,63 +17,63 @@
     "contributes": {
         "commands": [
             {
-                "command": "extension.insertSibling",
+                "command": "org.insertHeadingRespectContent",
                 "title": "Org: Insert Heading Respect Content"
             },
             {
-                "command": "extension.insertChild",
+                "command": "org.insertSubheading",
                 "title": "Org: Insert Subheading"
             },
             {
-                "command": "extension.demoteLine",
-                "title": "Org-mode: Do Demote"
+                "command": "org.demoteLine",
+                "title": "Org: Do Demote"
             },
             {
-                "command": "extension.promoteLine",
-                "title": "Org-mode: Do Promote"
+                "command": "org.promoteLine",
+                "title": "Org: Do Promote"
             },
             {
-                "command": "extension.insertTimestamp",
+                "command": "org.insertTimestamp",
                 "title": "Org: Timestamp"
             },
             {
-                "command": "extension.incrementContext",
+                "command": "org.incrementContext",
                 "title": "Org: Increment Context"
             },
             {
-                "command": "extension.decrementContext",
+                "command": "org.decrementContext",
                 "title": "Org: Decrement Context"
             },
             {
-                "command": "extension.incrementContext",
+                "command": "org.incrementContext",
                 "title": "Org: Increment Context"
             },
             {
-                "command": "extension.decrementContext",
+                "command": "org.decrementContext",
                 "title": "Org: Decrement Context"
             },
             {
-                "command": "extension.bold",
+                "command": "org.bold",
                 "title": "Org: Bold"
             },
             {
-                "command": "extension.italic",
+                "command": "org.italic",
                 "title": "Org: Italic"
             },
             {
-                "command": "extension.underline",
+                "command": "org.underline",
                 "title": "Org: Underline"
             },
             {
-                "command": "extension.code",
+                "command": "org.code",
                 "title": "Org: Code"
             },
             {
-                "command": "extension.verbose",
+                "command": "org.verbose",
                 "title": "Org: Verbose"
             },
             {
-                "command": "extension.literal",
+                "command": "org.literal",
                 "title": "Org: Literal"
             }
         ],

--- a/package.json
+++ b/package.json
@@ -45,14 +45,6 @@
                 "title": "Org: Decrement Context"
             },
             {
-                "command": "org.incrementContext",
-                "title": "Org: Increment Context"
-            },
-            {
-                "command": "org.decrementContext",
-                "title": "Org: Decrement Context"
-            },
-            {
                 "command": "org.bold",
                 "title": "Org: Bold"
             },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,10 +11,10 @@ import {
 export function activate(context: vscode.ExtensionContext) {
     let insertSiblingCmd = vscode.commands.registerTextEditorCommand('org.insertHeadingRespectContent', HeaderFunctions.insertSibling);
     let insertChildCmd = vscode.commands.registerTextEditorCommand('org.insertSubheading', HeaderFunctions.insertChild);
-    let demoteLineCmd = vscode.commands.registerTextEditorCommand('org.demoteLine', HeaderFunctions.demoteLine);
-    let promoteLineCmd = vscode.commands.registerTextEditorCommand('org.promoteLine', HeaderFunctions.promoteLine);
+    let demoteLineCmd = vscode.commands.registerTextEditorCommand('org.doDemote', HeaderFunctions.demoteLine);
+    let promoteLineCmd = vscode.commands.registerTextEditorCommand('org.doPromote', HeaderFunctions.promoteLine);
 
-    let insertTimestampCmd = vscode.commands.registerTextEditorCommand('org.insertTimestamp', (textEditor, edit) => {
+    let insertTimestampCmd = vscode.commands.registerTextEditorCommand('org.timestamp', (textEditor, edit) => {
       vscode.window.showInformationMessage('Inserting Date');
       TimestampFunctions.insertTimestamp(textEditor, edit);
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,26 +9,26 @@ import {
 } from './modify-context';
 
 export function activate(context: vscode.ExtensionContext) {
-    let insertSiblingCmd = vscode.commands.registerTextEditorCommand('extension.insertSibling', HeaderFunctions.insertSibling);
-    let insertChildCmd = vscode.commands.registerTextEditorCommand('extension.insertChild', HeaderFunctions.insertChild);
-    let demoteLineCmd = vscode.commands.registerTextEditorCommand('extension.demoteLine', HeaderFunctions.demoteLine);
-    let promoteLineCmd = vscode.commands.registerTextEditorCommand('extension.promoteLine', HeaderFunctions.promoteLine);
+    let insertSiblingCmd = vscode.commands.registerTextEditorCommand('org.insertHeadingRespectContent', HeaderFunctions.insertSibling);
+    let insertChildCmd = vscode.commands.registerTextEditorCommand('org.insertSubheading', HeaderFunctions.insertChild);
+    let demoteLineCmd = vscode.commands.registerTextEditorCommand('org.demoteLine', HeaderFunctions.demoteLine);
+    let promoteLineCmd = vscode.commands.registerTextEditorCommand('org.promoteLine', HeaderFunctions.promoteLine);
 
-    let insertTimestampCmd = vscode.commands.registerTextEditorCommand('extension.insertTimestamp', (textEditor, edit) => {
+    let insertTimestampCmd = vscode.commands.registerTextEditorCommand('org.insertTimestamp', (textEditor, edit) => {
       vscode.window.showInformationMessage('Inserting Date');
       TimestampFunctions.insertTimestamp(textEditor, edit);
     });
 
-    let incrementContextCmd = vscode.commands.registerTextEditorCommand('extension.incrementContext', incrementContext);
+    let incrementContextCmd = vscode.commands.registerTextEditorCommand('org.incrementContext', incrementContext);
 
-    let decrementContextCmd = vscode.commands.registerTextEditorCommand('extension.decrementContext', decrementContext);
+    let decrementContextCmd = vscode.commands.registerTextEditorCommand('org.decrementContext', decrementContext);
 
-    const boldCmd = vscode.commands.registerTextEditorCommand('extension.bold', MarkupFunctions.bold);
-    const italicCmd = vscode.commands.registerTextEditorCommand('extension.italic', MarkupFunctions.italic);
-    const underlineCmd = vscode.commands.registerTextEditorCommand('extension.underline', MarkupFunctions.underline);
-    const codeCmd = vscode.commands.registerTextEditorCommand('extension.code', MarkupFunctions.code);
-    const verboseCmd = vscode.commands.registerTextEditorCommand('extension.verbose', MarkupFunctions.verbose);
-    const literalCmd = vscode.commands.registerTextEditorCommand('extension.literal', MarkupFunctions.literal);
+    const boldCmd = vscode.commands.registerTextEditorCommand('org.bold', MarkupFunctions.bold);
+    const italicCmd = vscode.commands.registerTextEditorCommand('org.italic', MarkupFunctions.italic);
+    const underlineCmd = vscode.commands.registerTextEditorCommand('org.underline', MarkupFunctions.underline);
+    const codeCmd = vscode.commands.registerTextEditorCommand('org.code', MarkupFunctions.code);
+    const verboseCmd = vscode.commands.registerTextEditorCommand('org.verbose', MarkupFunctions.verbose);
+    const literalCmd = vscode.commands.registerTextEditorCommand('org.literal', MarkupFunctions.literal);
 
     context.subscriptions.push(insertSiblingCmd);
     context.subscriptions.push(insertChildCmd);


### PR DESCRIPTION
Keybindings are set using the command names. Here I've updated those command names to be more intuitive in two ways:
- They start with `org.` instead of the boilerplate `extension.`
- They mirror the "titles" a lá:
  -  "command": "org.insertSubheading",
  - "title": "Org: Insert Subheading"

Now when we / others specify keybindings, it will be easier to figure out which commands to associate them with.