### PR TITLE
Feature/source block support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,14 +137,6 @@ Install the extension. The rest will be taken care of.
 
 ## Known Issues
 
-### Folding
-
-VS Code's folding strategy is based on indentation. There is no indentation in Org. There are a number of feature requests to allow for header-level folding:
-- [language-aware folding #3422](https://github.com/Microsoft/vscode/issues/3422)
-- [Add code folding for markdown based on heading level #3347](https://github.com/Microsoft/vscode/issues/3347)
-
-Until Microsoft addresses those issues, it appears to be impossible to implement folding in Org.
-
 ### Colorization
 
 Colorization, bolding, italicization, and other modes of highlighting are handled differently by different themes. We have prioritized supporting the default VS Code themes (Dark+ and Light+). This prioritization means that some colors may not appear as expected in other themes, or that opportunities for more variance have been missed.

--- a/package.json
+++ b/package.json
@@ -252,7 +252,8 @@
         "vscode:prepublish": "tsc -p ./",
         "compile": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "node ./node_modules/vscode/bin/test"
+        "test": "node ./node_modules/vscode/bin/test",
+        "generate-syntax": "node syntaxes/populate-syntax.js"
     },
     "devDependencies": {
         "typescript": "^2.0.3",

--- a/src/org-folding-provider.ts
+++ b/src/org-folding-provider.ts
@@ -33,13 +33,11 @@ export class OrgFoldingProvider implements FoldingRangeProvider {
                 }
 
                 stack.push({ level, lineNumber });
-                
-            } else if (/^\s*#\+(BEGIN|END)_/.test(text)) {
-                if (text.startsWith('#+BEGIN_')) {
-                    blockStack = lineNumber;
-                } else {
-                    ranges.push(new FoldingRange(blockStack, lineNumber));
-                }
+
+            } else if (/^\s*#\+BEGIN_/.test(text)) {
+                blockStack = lineNumber;
+            } else if (/^\s*#\+END_/.test(text)) {
+                ranges.push(new FoldingRange(blockStack, lineNumber));
             }
         }
 

--- a/src/org-folding-provider.ts
+++ b/src/org-folding-provider.ts
@@ -14,27 +14,31 @@ export class OrgFoldingProvider implements FoldingRangeProvider {
 
         let stack: FoldStart[] = [];
         let ranges: FoldingRange[] = [];
+        let blockStack: number = null;
 
         for (let lineNumber = 0; lineNumber < count; lineNumber++) {
             const element = document.lineAt(lineNumber);
             const text = element.text;
 
-            if (!text.startsWith("*")) {
-                continue;
-            }
+            if (text.startsWith('*')) {
+                let level = 0;
+                while (text[level] === '*') {
+                    level++;
+                }
 
-            let level = 0;
-            while (text[level] === '*') {
-                level++;
-            }
+                const adjustmentCount = stack.length - level + 1;
+                for (let i = 0; i < adjustmentCount; i++) {
+                    const top = stack.pop();
+                    ranges.push(new FoldingRange(top.lineNumber, lineNumber - 1));
+                }
 
-            const adjustmentCount = stack.length - level + 1;
-            for (let i = 0; i < adjustmentCount; i++) {
-                const top = stack.pop();
-                ranges.push(new FoldingRange(top.lineNumber, lineNumber - 1));
+                stack.push({ level, lineNumber });
+            } else if (/^\s*#\+(BEGIN|END)_/.test(text)) {
+                if (text.startsWith('#+BEGIN_')) { blockStack = lineNumber; }
+                else {
+                    ranges.push(new FoldingRange(blockStack, lineNumber));
+                }
             }
-
-            stack.push({ level, lineNumber });
         }
 
         let top: FoldStart;

--- a/src/org-folding-provider.ts
+++ b/src/org-folding-provider.ts
@@ -33,9 +33,11 @@ export class OrgFoldingProvider implements FoldingRangeProvider {
                 }
 
                 stack.push({ level, lineNumber });
+                
             } else if (/^\s*#\+(BEGIN|END)_/.test(text)) {
-                if (text.startsWith('#+BEGIN_')) { blockStack = lineNumber; }
-                else {
+                if (text.startsWith('#+BEGIN_')) {
+                    blockStack = lineNumber;
+                } else {
                     ranges.push(new FoldingRange(blockStack, lineNumber));
                 }
             }

--- a/syntaxes/org.tmLanguage.json
+++ b/syntaxes/org.tmLanguage.json
@@ -1607,6 +1607,39 @@
                     ]
                 },
                 {
+                    "name": "meta.block.source.latex.org",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(latex|tex)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.latex",
+                            "patterns": [
+                                {
+                                    "include": "text.tex.latex"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
                     "name": "meta.block.source.unknown.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(\\w+)\\b\\s*(.*)$",
                     "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",

--- a/syntaxes/org.tmLanguage.json
+++ b/syntaxes/org.tmLanguage.json
@@ -57,8 +57,8 @@
             "patterns": [
                 {
                     "name": "meta.block.source.js.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(js|javascript|mjs|es6|jsx)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(js|javascript|mjs|es6|jsx)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -90,8 +90,8 @@
                 },
                 {
                     "name": "meta.block.source.js.regexp.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(js.regexp|regexp)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(js.regexp|regexp)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -123,8 +123,8 @@
                 },
                 {
                     "name": "meta.block.source.ts.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(ts|typescript)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(ts|typescript)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -156,8 +156,8 @@
                 },
                 {
                     "name": "meta.block.source.tsx.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(tsx)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(tsx)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -189,8 +189,8 @@
                 },
                 {
                     "name": "meta.block.source.java.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(java)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(java)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -222,8 +222,8 @@
                 },
                 {
                     "name": "meta.block.source.python.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -255,8 +255,8 @@
                 },
                 {
                     "name": "meta.block.source.regexp.python.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(regexp.python|re)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(regexp.python|re)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -288,8 +288,8 @@
                 },
                 {
                     "name": "meta.block.source.css.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(css)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(css)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -321,8 +321,8 @@
                 },
                 {
                     "name": "meta.block.source.lua.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(lua)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(lua)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -354,8 +354,8 @@
                 },
                 {
                     "name": "meta.block.source.ini.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(ini|conf|properties)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(ini|conf|properties)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -387,8 +387,8 @@
                 },
                 {
                     "name": "meta.block.source.makefile.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(makefile|Malefile)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(makefile|Malefile)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -420,8 +420,8 @@
                 },
                 {
                     "name": "meta.block.source.perl.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(perl|pl|pm)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(perl|pl|pm)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -453,8 +453,8 @@
                 },
                 {
                     "name": "meta.block.source.r.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(r|R|s|S|Rprofile)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(r|R|s|S|Rprofile)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -486,8 +486,8 @@
                 },
                 {
                     "name": "meta.block.source.ruby.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -519,8 +519,8 @@
                 },
                 {
                     "name": "meta.block.source.php.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(php|php3|php4|php5|phpt|phtml|aw|ctp)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(php|php3|php4|php5|phpt|phtml|aw|ctp)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -552,8 +552,8 @@
                 },
                 {
                     "name": "meta.block.source.sql.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(sql|ddl|dml)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(sql|ddl|dml)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -585,8 +585,8 @@
                 },
                 {
                     "name": "meta.block.source.asp.vb.net.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(asp.vb.net|vb)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(asp.vb.net|vb)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -618,8 +618,8 @@
                 },
                 {
                     "name": "meta.block.source.dosbatch.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(dosbatch|batch|bat)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(dosbatch|batch|bat)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -651,8 +651,8 @@
                 },
                 {
                     "name": "meta.block.source.clojure.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(clojure|clj|cljs)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(clojure|clj|cljs)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -684,8 +684,8 @@
                 },
                 {
                     "name": "meta.block.source.coffee.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(coffee|Cakefile|coffe.erb)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(coffee|Cakefile|coffe.erb)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -717,8 +717,8 @@
                 },
                 {
                     "name": "meta.block.source.c.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(c|h)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(c|h)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -750,8 +750,8 @@
                 },
                 {
                     "name": "meta.block.source.cpp.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(cpp|c\\+\\+|cxx)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(cpp|c\\+\\+|cxx)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -783,8 +783,8 @@
                 },
                 {
                     "name": "meta.block.source.objc.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(objc|objectivec|objective-c|mm|m|obj-c)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(objc|objectivec|objective-c|mm|m|obj-c)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -816,8 +816,8 @@
                 },
                 {
                     "name": "meta.block.source.diff.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(diff|patch|rej)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(diff|patch|rej)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -849,8 +849,8 @@
                 },
                 {
                     "name": "meta.block.source.dockerfile.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(dockerfile|Dockerfile)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(dockerfile|Dockerfile)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -882,8 +882,8 @@
                 },
                 {
                     "name": "meta.block.source.go.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(go|golang)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(go|golang)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -915,8 +915,8 @@
                 },
                 {
                     "name": "meta.block.source.groovy.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(groovy|gvy)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(groovy|gvy)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -948,8 +948,8 @@
                 },
                 {
                     "name": "meta.block.source.pug.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(pug|jade)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(pug|jade)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -981,8 +981,8 @@
                 },
                 {
                     "name": "meta.block.source.css.less.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(css.less|less)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(css.less|less)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1014,8 +1014,8 @@
                 },
                 {
                     "name": "meta.block.source.css.scss.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(css.scss|scss)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(css.scss|scss)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1047,8 +1047,8 @@
                 },
                 {
                     "name": "meta.block.source.perl.6.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(perl.6|perl6|p6|pl6|pm6|nqp)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(perl.6|perl6|p6|pl6|pm6|nqp)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1080,8 +1080,8 @@
                 },
                 {
                     "name": "meta.block.source.rust.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(rust|rs)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(rust|rs)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1113,8 +1113,8 @@
                 },
                 {
                     "name": "meta.block.source.scala.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(scala|sbt)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(scala|sbt)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1146,8 +1146,8 @@
                 },
                 {
                     "name": "meta.block.source.shell.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(shell|sh|bash|zsh|bashrc|bash_profile)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(shell|sh|bash|zsh|bashrc|bash_profile)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1179,8 +1179,8 @@
                 },
                 {
                     "name": "meta.block.source.cs.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(cs|csharp|c#)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(cs|csharp|c#)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1212,8 +1212,8 @@
                 },
                 {
                     "name": "meta.block.source.fs.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(fs|fsharp|f#)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(fs|fsharp|f#)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1245,8 +1245,8 @@
                 },
                 {
                     "name": "meta.block.source.dart.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(dart)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(dart)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1278,8 +1278,8 @@
                 },
                 {
                     "name": "meta.block.source.yaml.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(yaml|yml)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(yaml|yml)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1311,8 +1311,8 @@
                 },
                 {
                     "name": "meta.block.source.json.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(json)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(json)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1344,8 +1344,8 @@
                 },
                 {
                     "name": "meta.block.source.xml.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1377,8 +1377,8 @@
                 },
                 {
                     "name": "meta.block.source.xsl.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(xsl|xslt)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(xsl|xslt)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1410,8 +1410,8 @@
                 },
                 {
                     "name": "meta.block.source.markdown.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(markdown|md)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(markdown|md)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1443,8 +1443,8 @@
                 },
                 {
                     "name": "meta.block.source.orgmode.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(orgmode|org)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(orgmode|org)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1476,8 +1476,8 @@
                 },
                 {
                     "name": "meta.block.source.html.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(html|htm|shtml|xhtml|inc|tmpl|tpl)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(html|htm|shtml|xhtml|inc|tmpl|tpl)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1509,8 +1509,8 @@
                 },
                 {
                     "name": "meta.block.source.COMMIT_EDITMSG.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(COMMIT_EDITMSG|MERGE_MSG)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(COMMIT_EDITMSG|MERGE_MSG)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1542,8 +1542,8 @@
                 },
                 {
                     "name": "meta.block.source.git-rebase-todo.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(git-rebase-todo)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(git-rebase-todo)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1575,8 +1575,8 @@
                 },
                 {
                     "name": "meta.block.source.unknown.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(\\w+)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(\\w+)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1607,8 +1607,8 @@
             "patterns": [
                 {
                     "name": "meta.block.${2:/downcase}",
-                    "begin": "(?i)(#\\+BEGIN_(\\w+))\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_\\2)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_(\\w+))\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_\\2)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"

--- a/syntaxes/org.tmLanguage.json
+++ b/syntaxes/org.tmLanguage.json
@@ -58,7 +58,7 @@
                 {
                     "name": "meta.block.source.js.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(js|javascript|mjs|es6|jsx)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -91,7 +91,7 @@
                 {
                     "name": "meta.block.source.js.regexp.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(js.regexp|regexp)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -124,7 +124,7 @@
                 {
                     "name": "meta.block.source.ts.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(ts|typescript)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -157,7 +157,7 @@
                 {
                     "name": "meta.block.source.tsx.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(tsx)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -190,7 +190,7 @@
                 {
                     "name": "meta.block.source.java.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(java)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -223,7 +223,7 @@
                 {
                     "name": "meta.block.source.python.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -256,7 +256,7 @@
                 {
                     "name": "meta.block.source.regexp.python.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(regexp.python|re)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -289,7 +289,7 @@
                 {
                     "name": "meta.block.source.css.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(css)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -322,7 +322,7 @@
                 {
                     "name": "meta.block.source.lua.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(lua)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -355,7 +355,7 @@
                 {
                     "name": "meta.block.source.ini.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(ini|conf|properties)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -388,7 +388,7 @@
                 {
                     "name": "meta.block.source.makefile.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(makefile|Malefile)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -421,7 +421,7 @@
                 {
                     "name": "meta.block.source.perl.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(perl|pl|pm)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -454,7 +454,7 @@
                 {
                     "name": "meta.block.source.r.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(r|R|s|S|Rprofile)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -487,7 +487,7 @@
                 {
                     "name": "meta.block.source.ruby.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -520,7 +520,7 @@
                 {
                     "name": "meta.block.source.php.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(php|php3|php4|php5|phpt|phtml|aw|ctp)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -553,7 +553,7 @@
                 {
                     "name": "meta.block.source.sql.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(sql|ddl|dml)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -586,7 +586,7 @@
                 {
                     "name": "meta.block.source.asp.vb.net.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(asp.vb.net|vb)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -619,7 +619,7 @@
                 {
                     "name": "meta.block.source.dosbatch.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(dosbatch|batch|bat)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -652,7 +652,7 @@
                 {
                     "name": "meta.block.source.clojure.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(clojure|clj|cljs)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -685,7 +685,7 @@
                 {
                     "name": "meta.block.source.coffee.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(coffee|Cakefile|coffe.erb)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -718,7 +718,7 @@
                 {
                     "name": "meta.block.source.c.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(c|h)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -751,7 +751,7 @@
                 {
                     "name": "meta.block.source.cpp.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(cpp|c\\+\\+|cxx)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -784,7 +784,7 @@
                 {
                     "name": "meta.block.source.objc.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(objc|objectivec|objective-c|mm|m|obj-c)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -817,7 +817,7 @@
                 {
                     "name": "meta.block.source.diff.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(diff|patch|rej)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -850,7 +850,7 @@
                 {
                     "name": "meta.block.source.dockerfile.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(dockerfile|Dockerfile)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -883,7 +883,7 @@
                 {
                     "name": "meta.block.source.go.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(go|golang)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -916,7 +916,7 @@
                 {
                     "name": "meta.block.source.groovy.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(groovy|gvy)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -949,7 +949,7 @@
                 {
                     "name": "meta.block.source.lisp.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(lisp|emacs-lisp|common-lisp)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -982,7 +982,7 @@
                 {
                     "name": "meta.block.source.pug.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(pug|jade)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1015,7 +1015,7 @@
                 {
                     "name": "meta.block.source.css.less.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(css.less|less)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1048,7 +1048,7 @@
                 {
                     "name": "meta.block.source.css.scss.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(css.scss|scss)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1081,7 +1081,7 @@
                 {
                     "name": "meta.block.source.perl.6.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(perl.6|perl6|p6|pl6|pm6|nqp)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1114,7 +1114,7 @@
                 {
                     "name": "meta.block.source.rust.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(rust|rs)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1147,7 +1147,7 @@
                 {
                     "name": "meta.block.source.scala.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(scala|sbt)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1180,7 +1180,7 @@
                 {
                     "name": "meta.block.source.shell.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(shell|sh|bash|zsh|bashrc|bash_profile)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1213,7 +1213,7 @@
                 {
                     "name": "meta.block.source.cs.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(cs|csharp|c#)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1246,7 +1246,7 @@
                 {
                     "name": "meta.block.source.fs.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(fs|fsharp|f#)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1279,7 +1279,7 @@
                 {
                     "name": "meta.block.source.dart.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(dart)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1312,7 +1312,7 @@
                 {
                     "name": "meta.block.source.yaml.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(yaml|yml)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1345,7 +1345,7 @@
                 {
                     "name": "meta.block.source.json.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(json)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1378,7 +1378,7 @@
                 {
                     "name": "meta.block.source.xml.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1411,7 +1411,7 @@
                 {
                     "name": "meta.block.source.xsl.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(xsl|xslt)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1444,7 +1444,7 @@
                 {
                     "name": "meta.block.source.markdown.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(markdown|md)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1477,7 +1477,7 @@
                 {
                     "name": "meta.block.source.orgmode.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(orgmode|org)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1510,7 +1510,7 @@
                 {
                     "name": "meta.block.source.html.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(html|htm|shtml|xhtml|inc|tmpl|tpl)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1543,7 +1543,7 @@
                 {
                     "name": "meta.block.source.COMMIT_EDITMSG.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(COMMIT_EDITMSG|MERGE_MSG)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1576,7 +1576,7 @@
                 {
                     "name": "meta.block.source.git-rebase-todo.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(git-rebase-todo)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1609,7 +1609,7 @@
                 {
                     "name": "meta.block.source.latex.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(latex|tex)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1642,7 +1642,7 @@
                 {
                     "name": "meta.block.source.unknown.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(\\w+)\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"
@@ -1674,7 +1674,7 @@
                 {
                     "name": "meta.block.${2:/downcase}",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_(\\w+))\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_\\2)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_\\2)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"

--- a/syntaxes/org.tmLanguage.json
+++ b/syntaxes/org.tmLanguage.json
@@ -46,11 +46,14 @@
             "include": "#common"
         },
         {
-            "include": "#src-block"
+            "include": "#src-blocks"
+        },
+        {
+            "include": "#blocks"
         }
     ],
     "repository": {
-        "src-block": {
+        "src-blocks": {
             "patterns": [
                 {
                     "name": "meta.block.source.js.org",
@@ -1595,6 +1598,33 @@
                             "begin": "(^|\\G)(\\s*)(.*)",
                             "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.unknown"
+                        }
+                    ]
+                }
+            ]
+        },
+        "blocks": {
+            "patterns": [
+                {
+                    "name": "meta.block.${2:/downcase}",
+                    "begin": "(?i)(#\\+BEGIN_(\\w+))\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_\\2)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#common"
                         }
                     ]
                 }

--- a/syntaxes/org.tmLanguage.json
+++ b/syntaxes/org.tmLanguage.json
@@ -74,7 +74,14 @@
                     },
                     "patterns": [
                         {
-                            "include": "source.js"
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.js",
+                            "patterns": [
+                                {
+                                    "include": "source.js"
+                                }
+                            ]
                         }
                     ]
                 },
@@ -100,7 +107,14 @@
                     },
                     "patterns": [
                         {
-                            "include": "source.ts"
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.ts",
+                            "patterns": [
+                                {
+                                    "include": "source.ts"
+                                }
+                            ]
                         }
                     ]
                 },
@@ -126,7 +140,14 @@
                     },
                     "patterns": [
                         {
-                            "include": "source.java"
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.java",
+                            "patterns": [
+                                {
+                                    "include": "source.java"
+                                }
+                            ]
                         }
                     ]
                 },
@@ -152,7 +173,14 @@
                     },
                     "patterns": [
                         {
-                            "include": "source.python"
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.python",
+                            "patterns": [
+                                {
+                                    "include": "source.python"
+                                }
+                            ]
                         }
                     ]
                 },
@@ -175,7 +203,14 @@
                         "1": {
                             "name": "keyword.control.block.org"
                         }
-                    }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.unknown"
+                        }
+                    ]
                 }
             ]
         },

--- a/syntaxes/org.tmLanguage.json
+++ b/syntaxes/org.tmLanguage.json
@@ -153,7 +153,7 @@
                 },
                 {
                     "name": "meta.block.source.python.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(python|py)\\b\\s*(.*)$",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(python|py|gyp)\\b\\s*(.*)$",
                     "end": "(?i)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
@@ -179,6 +179,204 @@
                             "patterns": [
                                 {
                                     "include": "source.python"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.yaml.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(yaml|yml)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.yaml",
+                            "patterns": [
+                                {
+                                    "include": "source.yaml"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.json.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(json)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.json",
+                            "patterns": [
+                                {
+                                    "include": "source.json"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.xml.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(xml)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.xml",
+                            "patterns": [
+                                {
+                                    "include": "text.xml"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.markdown.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(markdown|md)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.markdown",
+                            "patterns": [
+                                {
+                                    "include": "text.html.markdown"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.orgmode.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(orgmode|org)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.orgmode",
+                            "patterns": [
+                                {
+                                    "include": "source.org"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.html.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(html|htm|shtml|xhtml|inc|tmpl|tpl)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.html",
+                            "patterns": [
+                                {
+                                    "include": "text.html.basic"
                                 }
                             ]
                         }

--- a/syntaxes/org.tmLanguage.json
+++ b/syntaxes/org.tmLanguage.json
@@ -78,7 +78,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.js",
                             "patterns": [
                                 {
@@ -111,7 +111,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.js.regexp",
                             "patterns": [
                                 {
@@ -144,7 +144,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.ts",
                             "patterns": [
                                 {
@@ -177,7 +177,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.tsx",
                             "patterns": [
                                 {
@@ -210,7 +210,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.java",
                             "patterns": [
                                 {
@@ -243,7 +243,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.python",
                             "patterns": [
                                 {
@@ -276,7 +276,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.regexp.python",
                             "patterns": [
                                 {
@@ -309,7 +309,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.css",
                             "patterns": [
                                 {
@@ -342,7 +342,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.lua",
                             "patterns": [
                                 {
@@ -375,7 +375,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.ini",
                             "patterns": [
                                 {
@@ -408,7 +408,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.makefile",
                             "patterns": [
                                 {
@@ -441,7 +441,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.perl",
                             "patterns": [
                                 {
@@ -474,7 +474,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.r",
                             "patterns": [
                                 {
@@ -507,7 +507,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.ruby",
                             "patterns": [
                                 {
@@ -540,7 +540,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.php",
                             "patterns": [
                                 {
@@ -573,7 +573,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.sql",
                             "patterns": [
                                 {
@@ -606,7 +606,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.asp.vb.net",
                             "patterns": [
                                 {
@@ -639,7 +639,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.dosbatch",
                             "patterns": [
                                 {
@@ -672,7 +672,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.clojure",
                             "patterns": [
                                 {
@@ -705,7 +705,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.coffee",
                             "patterns": [
                                 {
@@ -738,7 +738,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.c",
                             "patterns": [
                                 {
@@ -771,7 +771,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.cpp",
                             "patterns": [
                                 {
@@ -804,7 +804,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.objc",
                             "patterns": [
                                 {
@@ -837,7 +837,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.diff",
                             "patterns": [
                                 {
@@ -870,7 +870,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.dockerfile",
                             "patterns": [
                                 {
@@ -903,7 +903,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.go",
                             "patterns": [
                                 {
@@ -936,7 +936,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.groovy",
                             "patterns": [
                                 {
@@ -969,7 +969,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.lisp",
                             "patterns": [
                                 {
@@ -1002,7 +1002,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.pug",
                             "patterns": [
                                 {
@@ -1035,7 +1035,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.css.less",
                             "patterns": [
                                 {
@@ -1068,7 +1068,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.css.scss",
                             "patterns": [
                                 {
@@ -1101,7 +1101,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.perl.6",
                             "patterns": [
                                 {
@@ -1134,7 +1134,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.rust",
                             "patterns": [
                                 {
@@ -1167,7 +1167,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.scala",
                             "patterns": [
                                 {
@@ -1200,7 +1200,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.shell",
                             "patterns": [
                                 {
@@ -1233,7 +1233,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.cs",
                             "patterns": [
                                 {
@@ -1266,7 +1266,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.fs",
                             "patterns": [
                                 {
@@ -1299,7 +1299,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.dart",
                             "patterns": [
                                 {
@@ -1332,7 +1332,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.yaml",
                             "patterns": [
                                 {
@@ -1365,7 +1365,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.json",
                             "patterns": [
                                 {
@@ -1398,7 +1398,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.xml",
                             "patterns": [
                                 {
@@ -1431,7 +1431,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.xsl",
                             "patterns": [
                                 {
@@ -1464,7 +1464,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.markdown",
                             "patterns": [
                                 {
@@ -1497,7 +1497,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.orgmode",
                             "patterns": [
                                 {
@@ -1530,7 +1530,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.html",
                             "patterns": [
                                 {
@@ -1563,7 +1563,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.COMMIT_EDITMSG",
                             "patterns": [
                                 {
@@ -1596,7 +1596,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.git-rebase-todo",
                             "patterns": [
                                 {
@@ -1629,7 +1629,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.latex",
                             "patterns": [
                                 {
@@ -1662,7 +1662,7 @@
                     "patterns": [
                         {
                             "begin": "(^|\\G)(\\s*)(.*)",
-                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "while": "(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
                             "contentName": "meta.embedded.block.unknown"
                         }
                     ]

--- a/syntaxes/org.tmLanguage.json
+++ b/syntaxes/org.tmLanguage.json
@@ -947,6 +947,39 @@
                     ]
                 },
                 {
+                    "name": "meta.block.source.lisp.org",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(lisp|emacs-lisp|common-lisp)\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.lisp",
+                            "patterns": [
+                                {
+                                    "include": "source.lisp"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
                     "name": "meta.block.source.pug.org",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(pug|jade)\\b\\s*(.*)$",
                     "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",

--- a/syntaxes/org.tmLanguage.json
+++ b/syntaxes/org.tmLanguage.json
@@ -54,7 +54,7 @@
             "patterns": [
                 {
                     "name": "meta.block.source.js.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(js|javascript)\\b\\s*(.*)$",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(js|javascript|mjs|es6|jsx)\\b\\s*(.*)$",
                     "end": "(?i)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
@@ -80,6 +80,39 @@
                             "patterns": [
                                 {
                                     "include": "source.js"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.js.regexp.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(js.regexp|regexp)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.js.regexp",
+                            "patterns": [
+                                {
+                                    "include": "source.js.regexp"
                                 }
                             ]
                         }
@@ -113,6 +146,39 @@
                             "patterns": [
                                 {
                                     "include": "source.ts"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.tsx.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(tsx)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.tsx",
+                            "patterns": [
+                                {
+                                    "include": "source.tsx"
                                 }
                             ]
                         }
@@ -153,7 +219,7 @@
                 },
                 {
                     "name": "meta.block.source.python.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(python|py|gyp)\\b\\s*(.*)$",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi)\\b\\s*(.*)$",
                     "end": "(?i)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
@@ -179,6 +245,1029 @@
                             "patterns": [
                                 {
                                     "include": "source.python"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.regexp.python.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(regexp.python|re)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.regexp.python",
+                            "patterns": [
+                                {
+                                    "include": "source.regexp.python"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.css.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(css)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.css",
+                            "patterns": [
+                                {
+                                    "include": "source.css"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.lua.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(lua)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.lua",
+                            "patterns": [
+                                {
+                                    "include": "source.lua"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.ini.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(ini|conf|properties)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.ini",
+                            "patterns": [
+                                {
+                                    "include": "source.ini"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.makefile.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(makefile|Malefile)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.makefile",
+                            "patterns": [
+                                {
+                                    "include": "source.makefile"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.perl.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(perl|pl|pm)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.perl",
+                            "patterns": [
+                                {
+                                    "include": "source.perl"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.r.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(r|R|s|S|Rprofile)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.r",
+                            "patterns": [
+                                {
+                                    "include": "source.r"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.ruby.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.ruby",
+                            "patterns": [
+                                {
+                                    "include": "source.ruby"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.php.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(php|php3|php4|php5|phpt|phtml|aw|ctp)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.php",
+                            "patterns": [
+                                {
+                                    "include": "source.php"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.sql.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(sql|ddl|dml)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.sql",
+                            "patterns": [
+                                {
+                                    "include": "source.sql"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.asp.vb.net.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(asp.vb.net|vb)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.asp.vb.net",
+                            "patterns": [
+                                {
+                                    "include": "source.asp.vb.net"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.dosbatch.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(dosbatch|batch|bat)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.dosbatch",
+                            "patterns": [
+                                {
+                                    "include": "source.dosbatch"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.clojure.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(clojure|clj|cljs)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.clojure",
+                            "patterns": [
+                                {
+                                    "include": "source.clojure"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.coffee.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(coffee|Cakefile|coffe.erb)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.coffee",
+                            "patterns": [
+                                {
+                                    "include": "source.coffee"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.c.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(c|h)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.c",
+                            "patterns": [
+                                {
+                                    "include": "source.c"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.cpp.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(cpp|c\\+\\+|cxx)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.cpp",
+                            "patterns": [
+                                {
+                                    "include": "source.cpp"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.objc.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(objc|objectivec|objective-c|mm|m|obj-c)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.objc",
+                            "patterns": [
+                                {
+                                    "include": "source.objc"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.diff.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(diff|patch|rej)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.diff",
+                            "patterns": [
+                                {
+                                    "include": "source.diff"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.dockerfile.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(dockerfile|Dockerfile)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.dockerfile",
+                            "patterns": [
+                                {
+                                    "include": "source.dockerfile"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.go.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(go|golang)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.go",
+                            "patterns": [
+                                {
+                                    "include": "source.go"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.groovy.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(groovy|gvy)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.groovy",
+                            "patterns": [
+                                {
+                                    "include": "source.groovy"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.pug.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(pug|jade)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.pug",
+                            "patterns": [
+                                {
+                                    "include": "source.pug"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.css.less.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(css.less|less)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.css.less",
+                            "patterns": [
+                                {
+                                    "include": "source.css.less"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.css.scss.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(css.scss|scss)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.css.scss",
+                            "patterns": [
+                                {
+                                    "include": "source.css.scss"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.perl.6.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(perl.6|perl6|p6|pl6|pm6|nqp)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.perl.6",
+                            "patterns": [
+                                {
+                                    "include": "source.perl.6"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.rust.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(rust|rs)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.rust",
+                            "patterns": [
+                                {
+                                    "include": "source.rust"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.scala.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(scala|sbt)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.scala",
+                            "patterns": [
+                                {
+                                    "include": "source.scala"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.shell.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(shell|sh|bash|zsh|bashrc|bash_profile)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.shell",
+                            "patterns": [
+                                {
+                                    "include": "source.shell"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.cs.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(cs|csharp|c#)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.cs",
+                            "patterns": [
+                                {
+                                    "include": "source.cs"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.fs.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(fs|fsharp|f#)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.fs",
+                            "patterns": [
+                                {
+                                    "include": "source.fs"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.dart.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(dart)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.dart",
+                            "patterns": [
+                                {
+                                    "include": "source.dart"
                                 }
                             ]
                         }
@@ -252,7 +1341,7 @@
                 },
                 {
                     "name": "meta.block.source.xml.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(xml)\\b\\s*(.*)$",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)\\b\\s*(.*)$",
                     "end": "(?i)(#\\+END_SRC)$",
                     "beginCaptures": {
                         "1": {
@@ -278,6 +1367,39 @@
                             "patterns": [
                                 {
                                     "include": "text.xml"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.xsl.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(xsl|xslt)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.xsl",
+                            "patterns": [
+                                {
+                                    "include": "text.xml.xsl"
                                 }
                             ]
                         }
@@ -377,6 +1499,72 @@
                             "patterns": [
                                 {
                                     "include": "text.html.basic"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.COMMIT_EDITMSG.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(COMMIT_EDITMSG|MERGE_MSG)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.COMMIT_EDITMSG",
+                            "patterns": [
+                                {
+                                    "include": "text.git-commit"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.block.source.git-rebase-todo.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(git-rebase-todo)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "begin": "(^|\\G)(\\s*)(.*)",
+                            "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                            "contentName": "meta.embedded.block.git-rebase-todo",
+                            "patterns": [
+                                {
+                                    "include": "text.git-rebase"
                                 }
                             ]
                         }

--- a/syntaxes/org.tmLanguage.json
+++ b/syntaxes/org.tmLanguage.json
@@ -340,7 +340,7 @@
         "keywords": {
             "patterns": [
                 {
-                    "match": "^(#\\+.*:)\\s(.*)$",
+                    "match": "^(#\\+\\w+:)\\s(.*)$",
                     "captures": {
                         "1": {
                             "name": "support.type.property-name.org"

--- a/syntaxes/org.tmLanguage.json
+++ b/syntaxes/org.tmLanguage.json
@@ -44,9 +44,42 @@
         },
         {
             "include": "#common"
+        },
+        {
+            "include": "#src-block"
         }
     ],
     "repository": {
+        "src-block": {
+           "patterns": [
+                {
+                  "name": "meta.block.source.js.orgmode",
+                  "begin": "(?i)(#\\+BEGIN_SRC)\\s+(js|javascript)\\s*(.*)$",
+                  "end": "(?i)(#\\+END_SRC)$",
+                  "beginCaptures": {
+                    "1": {
+                      "name": "keyword.control.block.org"
+                    },
+                    "2": {
+                      "name": "constant.other.language.org"
+                    },
+                    "3": {
+                      "name": "string.other.header-args.org"
+                    }
+                  },
+                  "endCaptures": {
+                    "1": {
+                      "name": "keyword.control.block.org"
+                    }
+                  },
+                  "patterns": [
+                    {
+                      "include": "source.js"
+                    }
+                  ]
+                }
+           ]
+        },
         "common": {
             "patterns": [
                 {

--- a/syntaxes/org.tmLanguage.json
+++ b/syntaxes/org.tmLanguage.json
@@ -155,6 +155,27 @@
                             "include": "source.python"
                         }
                     ]
+                },
+                {
+                    "name": "meta.block.source.unknown.org",
+                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(\\w+)\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_SRC)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "2": {
+                            "name": "constant.other.language.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    }
                 }
             ]
         },

--- a/syntaxes/org.tmLanguage.template.json
+++ b/syntaxes/org.tmLanguage.template.json
@@ -61,7 +61,7 @@
                 {
                     "name": "meta.block.${2:/downcase}",
                     "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_(\\w+))\\b\\s*(.*)$",
-                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_\\2)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_\\2)\\s*$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"

--- a/syntaxes/org.tmLanguage.template.json
+++ b/syntaxes/org.tmLanguage.template.json
@@ -46,12 +46,42 @@
             "include": "#common"
         },
         {
-            "include": "#src-block"
+            "include": "#src-blocks"
+        },
+        {
+            "include": "#blocks"
         }
     ],
     "repository": {
-        "src-block": {
-           "patterns": "// Dynamically Generated"
+        "src-blocks": {
+            "patterns": "// Dynamically Generated"
+        },
+        "blocks": {
+            "patterns": [
+                {
+                    "name": "meta.block.${2:/downcase}",
+                    "begin": "(?i)(#\\+BEGIN_(\\w+))\\b\\s*(.*)$",
+                    "end": "(?i)(#\\+END_\\2)$",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        },
+                        "3": {
+                            "name": "string.other.header-args.org"
+                        }
+                    },
+                    "endCaptures": {
+                        "1": {
+                            "name": "keyword.control.block.org"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#common"
+                        }
+                    ]
+                }
+            ]
         },
         "common": {
             "patterns": [

--- a/syntaxes/org.tmLanguage.template.json
+++ b/syntaxes/org.tmLanguage.template.json
@@ -51,112 +51,7 @@
     ],
     "repository": {
         "src-block": {
-            "patterns": [
-                {
-                    "name": "meta.block.source.js.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(js|javascript)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
-                    "beginCaptures": {
-                        "1": {
-                            "name": "keyword.control.block.org"
-                        },
-                        "2": {
-                            "name": "constant.other.language.org"
-                        },
-                        "3": {
-                            "name": "string.other.header-args.org"
-                        }
-                    },
-                    "endCaptures": {
-                        "1": {
-                            "name": "keyword.control.block.org"
-                        }
-                    },
-                    "patterns": [
-                        {
-                            "include": "source.js"
-                        }
-                    ]
-                },
-                {
-                    "name": "meta.block.source.ts.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(ts|typescript)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
-                    "beginCaptures": {
-                        "1": {
-                            "name": "keyword.control.block.org"
-                        },
-                        "2": {
-                            "name": "constant.other.language.org"
-                        },
-                        "3": {
-                            "name": "string.other.header-args.org"
-                        }
-                    },
-                    "endCaptures": {
-                        "1": {
-                            "name": "keyword.control.block.org"
-                        }
-                    },
-                    "patterns": [
-                        {
-                            "include": "source.ts"
-                        }
-                    ]
-                },
-                {
-                    "name": "meta.block.source.java.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(java)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
-                    "beginCaptures": {
-                        "1": {
-                            "name": "keyword.control.block.org"
-                        },
-                        "2": {
-                            "name": "constant.other.language.org"
-                        },
-                        "3": {
-                            "name": "string.other.header-args.org"
-                        }
-                    },
-                    "endCaptures": {
-                        "1": {
-                            "name": "keyword.control.block.org"
-                        }
-                    },
-                    "patterns": [
-                        {
-                            "include": "source.java"
-                        }
-                    ]
-                },
-                {
-                    "name": "meta.block.source.python.org",
-                    "begin": "(?i)(#\\+BEGIN_SRC)\\s+(python|py)\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_SRC)$",
-                    "beginCaptures": {
-                        "1": {
-                            "name": "keyword.control.block.org"
-                        },
-                        "2": {
-                            "name": "constant.other.language.org"
-                        },
-                        "3": {
-                            "name": "string.other.header-args.org"
-                        }
-                    },
-                    "endCaptures": {
-                        "1": {
-                            "name": "keyword.control.block.org"
-                        }
-                    },
-                    "patterns": [
-                        {
-                            "include": "source.python"
-                        }
-                    ]
-                }
-            ]
+           "patterns": "// Dynamically Generated"
         },
         "common": {
             "patterns": [
@@ -286,7 +181,7 @@
             "patterns": [
                 {
                     "name": "markup.italic.org",
-                    "match": "(^|\\s)/[^\\s](.*?[^\\s])?/($|\\W)"
+                    "match": "(^|\\s)\/[^\\s](.*?[^\\s])?\/($|\\W)"
                 }
             ]
         },

--- a/syntaxes/org.tmLanguage.template.json
+++ b/syntaxes/org.tmLanguage.template.json
@@ -60,8 +60,8 @@
             "patterns": [
                 {
                     "name": "meta.block.${2:/downcase}",
-                    "begin": "(?i)(#\\+BEGIN_(\\w+))\\b\\s*(.*)$",
-                    "end": "(?i)(#\\+END_\\2)$",
+                    "begin": "(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_(\\w+))\\b\\s*(.*)$",
+                    "end": "(?i)(?:^|\\G)(?:\\s*)(#\\+END_\\2)$",
                     "beginCaptures": {
                         "1": {
                             "name": "keyword.control.block.org"

--- a/syntaxes/org.tmLanguage.template.json
+++ b/syntaxes/org.tmLanguage.template.json
@@ -235,7 +235,7 @@
         "keywords": {
             "patterns": [
                 {
-                    "match": "^(#\\+.*:)\\s(.*)$",
+                    "match": "^(#\\+\\w+:)\\s(.*)$",
                     "captures": {
                         "1": {
                             "name": "support.type.property-name.org"

--- a/syntaxes/populate-syntax.js
+++ b/syntaxes/populate-syntax.js
@@ -30,10 +30,17 @@ const generateBlockSourceDefinition = (scope, match, sourceLanguage) => {
             "1": {
                 "name": "keyword.control.block.org"
             }
-        }
+        },
+        patterns: [
+            {
+                "begin": "(^|\\G)(\\s*)(.*)",
+                "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
+                "contentName": `meta.embedded.block.${scope}`
+            }
+        ]
     }
     if (sourceLanguage)
-        basePattern.patterns = [
+        basePattern.patterns[0].patterns = [
             {
                 "include": sourceLanguage
             }

--- a/syntaxes/populate-syntax.js
+++ b/syntaxes/populate-syntax.js
@@ -64,8 +64,8 @@ const generateDefinitionForMarkupLanguage = language =>
 const generateBlockSourceDefinition = (scope, match, sourceLanguage) => {
     var basePattern = {
         name: `meta.block.source.${scope}.org`,
-        begin: `(?i)(#\\+BEGIN_SRC)\\s+(${match})\\b\\s*(.*)$`,
-        end: "(?i)(#\\+END_SRC)$",
+        begin: `(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(${match})\\b\\s*(.*)$`,
+        end: "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
         beginCaptures: {
             "1": {
                 "name": "keyword.control.block.org"

--- a/syntaxes/populate-syntax.js
+++ b/syntaxes/populate-syntax.js
@@ -7,38 +7,46 @@ const languages = [
     ['java'],
     ['python', 'py']
 ];
+const generateDefinitionForLanguage = language =>
+    generateBlockSourceDefinition(language[0], language.join('|'), `source.${language[0]}`)
 
-const generateDefinitionForLanguage = language => ({
-    "name": `meta.block.source.${language[0]}.org`,
-    "begin": `(?i)(#\\+BEGIN_SRC)\\s+(${language.join('|')})\\b\\s*(.*)$`,
-    "end": "(?i)(#\\+END_SRC)$",
-    "beginCaptures": {
-        "1": {
-            "name": "keyword.control.block.org"
+const generateBlockSourceDefinition = (scope, match, sourceLanguage) => {
+    var basePattern = {
+        name: `meta.block.source.${scope}.org`,
+        begin: `(?i)(#\\+BEGIN_SRC)\\s+(${match})\\b\\s*(.*)$`,
+        end: "(?i)(#\\+END_SRC)$",
+        beginCaptures: {
+            "1": {
+                "name": "keyword.control.block.org"
+            },
+            "2": {
+                "name": "constant.other.language.org"
+            },
+            "3": {
+                "name": "string.other.header-args.org"
+            }
         },
-        "2": {
-            "name": "constant.other.language.org"
-        },
-        "3": {
-            "name": "string.other.header-args.org"
+        endCaptures: {
+            "1": {
+                "name": "keyword.control.block.org"
+            }
         }
-    },
-    "endCaptures": {
-        "1": {
-            "name": "keyword.control.block.org"
-        }
-    },
-    "patterns": [
-        {
-            "include": `source.${language[0]}`
-        }
-    ]
-});
+    }
+    if (sourceLanguage)
+        basePattern.patterns = [
+            {
+                "include": sourceLanguage
+            }
+        ];
+    return basePattern;
+};
 
 const generateGrammar = () => {
     const grammarTemplate = fs.readFileSync(`${__dirname}/org.tmLanguage.template.json`);
     const jsonGrammar = JSON.parse(grammarTemplate);
-    jsonGrammar.repository['src-block'].patterns = languages.map(generateDefinitionForLanguage);
+    const languageDefinitions = languages.map(generateDefinitionForLanguage)
+    languageDefinitions.push(generateBlockSourceDefinition('unknown', '\\w+', null))
+    jsonGrammar.repository['src-block'].patterns = languageDefinitions;
     fs.writeFileSync(`${__dirname}/org.tmLanguage.json`, JSON.stringify(jsonGrammar, null, 4));
 };
 

--- a/syntaxes/populate-syntax.js
+++ b/syntaxes/populate-syntax.js
@@ -67,7 +67,7 @@ const generateBlockSourceDefinition = (scope, match, sourceLanguage) => {
     var basePattern = {
         name: `meta.block.source.${scope}.org`,
         begin: `(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(${match})\\b\\s*(.*)$`,
-        end: '(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$',
+        end: '(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)\\s*$',
         beginCaptures: {
             '1': {
                 name: 'keyword.control.block.org'

--- a/syntaxes/populate-syntax.js
+++ b/syntaxes/populate-syntax.js
@@ -53,7 +53,8 @@ const markupLanguages = [
     ['source.org', 'orgmode', 'org'],
     ['text.html.basic', 'html', 'htm', 'shtml', 'xhtml', 'inc', 'tmpl', 'tpl'],
     ['text.git-commit', 'COMMIT_EDITMSG', 'MERGE_MSG'],
-    ['text.git-rebase', 'git-rebase-todo']
+    ['text.git-rebase', 'git-rebase-todo'],
+    ['text.tex.latex', 'latex', 'tex']
 ];
 
 const generateDefinitionForProgrammingLanguage = language =>

--- a/syntaxes/populate-syntax.js
+++ b/syntaxes/populate-syntax.js
@@ -1,0 +1,48 @@
+// Script that populate syntax with list of language
+const fs = require('fs');
+
+const languages = [
+    ['js', 'javascript'],
+    ['ts', 'typescript'],
+    ['java'],
+    ['python', 'py']
+];
+
+const generateDefinitionForLanguage = language => ({
+    "name": `meta.block.source.${language[0]}.org`,
+    "begin": `(?i)(#\\+BEGIN_SRC)\\s+(${language.join('|')})\\b\\s*(.*)$`,
+    "end": "(?i)(#\\+END_SRC)$",
+    "beginCaptures": {
+        "1": {
+            "name": "keyword.control.block.org"
+        },
+        "2": {
+            "name": "constant.other.language.org"
+        },
+        "3": {
+            "name": "string.other.header-args.org"
+        }
+    },
+    "endCaptures": {
+        "1": {
+            "name": "keyword.control.block.org"
+        }
+    },
+    "patterns": [
+        {
+            "include": `source.${language[0]}`
+        }
+    ]
+});
+
+const generateGrammar = () => {
+    const grammarTemplate = fs.readFileSync(`${__dirname}/org.tmLanguage.template.json`);
+    const jsonGrammar = JSON.parse(grammarTemplate);
+    jsonGrammar.repository['src-block'].patterns = languages.map(generateDefinitionForLanguage);
+    fs.writeFileSync(`${__dirname}/org.tmLanguage.json`, JSON.stringify(jsonGrammar, null, 4));
+};
+
+if (!module.parent) {
+    console.log('Regenerating the grammar')
+    generateGrammar();
+}

--- a/syntaxes/populate-syntax.js
+++ b/syntaxes/populate-syntax.js
@@ -1,14 +1,27 @@
 // Script that populate syntax with list of language
 const fs = require('fs');
 
-const languages = [
+const programmingLanguages = [
     ['js', 'javascript'],
     ['ts', 'typescript'],
     ['java'],
-    ['python', 'py']
+    ['python', 'py', 'gyp']
 ];
-const generateDefinitionForLanguage = language =>
-    generateBlockSourceDefinition(language[0], language.join('|'), `source.${language[0]}`)
+
+const markupLanguages = [
+    ['source.yaml', 'yaml', 'yml'],
+    ['source.json', 'json'],
+    ['text.xml', 'xml'],
+    ['text.html.markdown', 'markdown', 'md'],
+    ['source.org', 'orgmode', 'org'],
+    ['text.html.basic', 'html', 'htm', 'shtml', 'xhtml', 'inc', 'tmpl', 'tpl']
+];
+
+const generateDefinitionForProgrammingLanguage = language =>
+    generateBlockSourceDefinition(language[0], language.join('|'), `source.${language[0]}`);
+
+const generateDefinitionForMarkupLanguage = language =>
+    generateBlockSourceDefinition(language[1], language.slice(1).join('|'), language[0]);
 
 const generateBlockSourceDefinition = (scope, match, sourceLanguage) => {
     var basePattern = {
@@ -51,7 +64,8 @@ const generateBlockSourceDefinition = (scope, match, sourceLanguage) => {
 const generateGrammar = () => {
     const grammarTemplate = fs.readFileSync(`${__dirname}/org.tmLanguage.template.json`);
     const jsonGrammar = JSON.parse(grammarTemplate);
-    const languageDefinitions = languages.map(generateDefinitionForLanguage)
+    const languageDefinitions = programmingLanguages.map(generateDefinitionForProgrammingLanguage)
+        .concat(markupLanguages.map(generateDefinitionForMarkupLanguage));
     languageDefinitions.push(generateBlockSourceDefinition('unknown', '\\w+', null))
     jsonGrammar.repository['src-block'].patterns = languageDefinitions;
     fs.writeFileSync(`${__dirname}/org.tmLanguage.json`, JSON.stringify(jsonGrammar, null, 4));

--- a/syntaxes/populate-syntax.js
+++ b/syntaxes/populate-syntax.js
@@ -105,7 +105,7 @@ const generateGrammar = () => {
     const languageDefinitions = programmingLanguages.map(generateDefinitionForProgrammingLanguage)
         .concat(markupLanguages.map(generateDefinitionForMarkupLanguage));
     languageDefinitions.push(generateBlockSourceDefinition('unknown', '\\w+', null))
-    jsonGrammar.repository['src-block'].patterns = languageDefinitions;
+    jsonGrammar.repository['src-blocks'].patterns = languageDefinitions;
     fs.writeFileSync(`${__dirname}/org.tmLanguage.json`, JSON.stringify(jsonGrammar, null, 4));
 };
 

--- a/syntaxes/populate-syntax.js
+++ b/syntaxes/populate-syntax.js
@@ -7,7 +7,7 @@ const programmingLanguages = [
     ['ts', 'typescript'],
     ['tsx'],
     ['java'],
-    ['python', 'py','py3','rpy','pyw','cpy','SConstruct','Sconstruct','sconstruct','SConscript','gyp','gypi'],
+    ['python', 'py', 'py3', 'rpy', 'pyw', 'cpy', 'SConstruct', 'Sconstruct', 'sconstruct', 'SConscript', 'gyp', 'gypi'],
     ['regexp.python', 're'],
     ['css'],
     ['lua'],
@@ -16,7 +16,7 @@ const programmingLanguages = [
     ['perl', 'pl', 'pm'],
     ['r', 'R', 's', 'S', 'Rprofile'],
     ['ruby', 'rb', 'rbx', 'rjs', 'Rakefile', 'rake', 'cgi', 'fcgi', 'gemspec', 'irbrc', 'Capfile', 'ru', 'prawn', 'Cheffile', 'Gemfile', 'Guardfile', 'Hobofile', 'Vagrantfile', 'Appraisals', 'Rantfile', 'Berksfile', 'Berksfile.lock', 'Thorfile', 'Puppetfile'],
-    ["php", "php3", "php4", "php5", "phpt", "phtml", "aw", "ctp"],
+    ['php', 'php3', 'php4', 'php5', 'phpt', 'phtml', 'aw', 'ctp'],
     ['sql', 'ddl', 'dml'],
     ['asp.vb.net', 'vb'],
     ['dosbatch', 'batch', 'bat'],
@@ -29,6 +29,7 @@ const programmingLanguages = [
     ['dockerfile', 'Dockerfile'],
     ['go', 'golang'],
     ['groovy', 'gvy'],
+    ['lisp', 'emacs-lisp', 'common-lisp'],
     ['pug', 'jade'],
     ['css.less', 'less'],
     ['css.scss', 'scss'],
@@ -36,8 +37,8 @@ const programmingLanguages = [
     ['rust', 'rs'],
     ['scala', 'sbt'],
     ['shell', 'sh', 'bash', 'zsh', 'bashrc', 'bash_profile'],
-    ['cs','csharp','c#'],
-    ['fs','fsharp','f#'],
+    ['cs', 'csharp', 'c#'],
+    ['fs', 'fsharp', 'f#'],
     ['dart']
 ];
 // List of language retrieve from https://github.com/Microsoft/vscode/blob/master/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json
@@ -65,35 +66,35 @@ const generateBlockSourceDefinition = (scope, match, sourceLanguage) => {
     var basePattern = {
         name: `meta.block.source.${scope}.org`,
         begin: `(?i)(?:^|\\G)(?:\\s*)(#\\+BEGIN_SRC)\\s+(${match})\\b\\s*(.*)$`,
-        end: "(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$",
+        end: '(?i)(?:^|\\G)(?:\\s*)(#\\+END_SRC)$',
         beginCaptures: {
-            "1": {
-                "name": "keyword.control.block.org"
+            '1': {
+                name: 'keyword.control.block.org'
             },
-            "2": {
-                "name": "constant.other.language.org"
+            '2': {
+                name: 'constant.other.language.org'
             },
-            "3": {
-                "name": "string.other.header-args.org"
+            '3': {
+                name: 'string.other.header-args.org'
             }
         },
         endCaptures: {
-            "1": {
-                "name": "keyword.control.block.org"
+            '1': {
+                name: 'keyword.control.block.org'
             }
         },
         patterns: [
             {
-                "begin": "(^|\\G)(\\s*)(.*)",
-                "while": "(^|\\G)(?!\\s*#\\+END_SRC\\s*)",
-                "contentName": `meta.embedded.block.${scope}`
+                begin: '(^|\\G)(\\s*)(.*)',
+                while: '(^|\\G)(?!\\s*#\\+END_SRC\\s*)',
+                contentName: `meta.embedded.block.${scope}`
             }
         ]
     }
     if (sourceLanguage)
         basePattern.patterns[0].patterns = [
             {
-                "include": sourceLanguage
+                include: sourceLanguage
             }
         ];
     return basePattern;

--- a/syntaxes/populate-syntax.js
+++ b/syntaxes/populate-syntax.js
@@ -2,19 +2,57 @@
 const fs = require('fs');
 
 const programmingLanguages = [
-    ['js', 'javascript'],
+    ['js', 'javascript', 'mjs', 'es6', 'jsx'],
+    ['js.regexp', 'regexp'],
     ['ts', 'typescript'],
+    ['tsx'],
     ['java'],
-    ['python', 'py', 'gyp']
+    ['python', 'py','py3','rpy','pyw','cpy','SConstruct','Sconstruct','sconstruct','SConscript','gyp','gypi'],
+    ['regexp.python', 're'],
+    ['css'],
+    ['lua'],
+    ['ini', 'conf', 'properties'],
+    ['makefile', 'Malefile'],
+    ['perl', 'pl', 'pm'],
+    ['r', 'R', 's', 'S', 'Rprofile'],
+    ['ruby', 'rb', 'rbx', 'rjs', 'Rakefile', 'rake', 'cgi', 'fcgi', 'gemspec', 'irbrc', 'Capfile', 'ru', 'prawn', 'Cheffile', 'Gemfile', 'Guardfile', 'Hobofile', 'Vagrantfile', 'Appraisals', 'Rantfile', 'Berksfile', 'Berksfile.lock', 'Thorfile', 'Puppetfile'],
+    ["php", "php3", "php4", "php5", "phpt", "phtml", "aw", "ctp"],
+    ['sql', 'ddl', 'dml'],
+    ['asp.vb.net', 'vb'],
+    ['dosbatch', 'batch', 'bat'],
+    ['clojure', 'clj', 'cljs'],
+    ['coffee', 'Cakefile', 'coffe.erb'],
+    ['c', 'h'],
+    ['cpp', 'c\\+\\+', 'cxx'],
+    ['objc', 'objectivec', 'objective-c', 'mm', 'm', 'obj-c'],
+    ['diff', 'patch', 'rej'],
+    ['dockerfile', 'Dockerfile'],
+    ['go', 'golang'],
+    ['groovy', 'gvy'],
+    ['pug', 'jade'],
+    ['css.less', 'less'],
+    ['css.scss', 'scss'],
+    ['perl.6', 'perl6', 'p6', 'pl6', 'pm6', 'nqp'],
+    ['rust', 'rs'],
+    ['scala', 'sbt'],
+    ['shell', 'sh', 'bash', 'zsh', 'bashrc', 'bash_profile'],
+    ['cs','csharp','c#'],
+    ['fs','fsharp','f#'],
+    ['dart']
 ];
+// List of language retrieve from https://github.com/Microsoft/vscode/blob/master/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json
+// Preproced by the following jq command: jq '.repository.block.repository|to_entries[]|{block: .key, names: .value.begin, source: .value.patterns[0].patterns[0].include?}'
 
 const markupLanguages = [
     ['source.yaml', 'yaml', 'yml'],
     ['source.json', 'json'],
-    ['text.xml', 'xml'],
+    ['text.xml', 'xml', 'xsd', 'tld', 'jsp', 'pt', 'cpt', 'dtml', 'rss', 'opml'],
+    ['text.xml.xsl', 'xsl', 'xslt'],
     ['text.html.markdown', 'markdown', 'md'],
     ['source.org', 'orgmode', 'org'],
-    ['text.html.basic', 'html', 'htm', 'shtml', 'xhtml', 'inc', 'tmpl', 'tpl']
+    ['text.html.basic', 'html', 'htm', 'shtml', 'xhtml', 'inc', 'tmpl', 'tpl'],
+    ['text.git-commit', 'COMMIT_EDITMSG', 'MERGE_MSG'],
+    ['text.git-rebase', 'git-rebase-todo']
 ];
 
 const generateDefinitionForProgrammingLanguage = language =>

--- a/syntaxes/populate-syntax.js
+++ b/syntaxes/populate-syntax.js
@@ -87,7 +87,7 @@ const generateBlockSourceDefinition = (scope, match, sourceLanguage) => {
         patterns: [
             {
                 begin: '(^|\\G)(\\s*)(.*)',
-                while: '(^|\\G)(?!\\s*#\\+END_SRC\\s*)',
+                while: '(?i)(^|\\G)(?!\\s*#\\+END_SRC\\s*)',
                 contentName: `meta.embedded.block.${scope}`
             }
         ]


### PR DESCRIPTION
### Implement Support for coding block, and generic block with syntax highlight and folding

I took inspiration from vscode markdown plugin, but instead to duplicate the scope definition by hand, I prefered to generate it from a language specification. This is done by the `populate-syntax.js` script that regenerate the grammar from the config and a template (which is the original grammar). This can be invoked with `npm run generate-syntax`


Can't wait to hear from your feedbacks @ajtoo ! 😃 
Feel free to ask any question.

#### Here is a preview:

<img width="286" alt="capture d ecran 2018-05-28 23 52 48" src="https://user-images.githubusercontent.com/2601132/40630727-67772c00-62d5-11e8-8cee-b0ca77f01e57.png">


Should close #103 