### PR TITLE
Increment timestamp context no matter what

### DIFF
--- a/src/cursor-context.ts
+++ b/src/cursor-context.ts
@@ -26,7 +26,7 @@ export default function getCursorContext(textEditor: TextEditor, edit: TextEdito
     const curLine = Util.getLine(document, cursorPos);
 
     // Match for timestamp
-    const timestampRegexp = /\[\d{4}-\d{1,2}-\d{1,2}(?: \w{3})?\]/g;
+    const timestampRegexp = /\[.*?\]/g;
     let match;
 
     while ((match = timestampRegexp.exec(curLine)) != null) {


### PR DESCRIPTION
This will fix #150 issue which when you're using timestamp
surrounded by e.g.  `* [timestamp]`  it'll lead to `* TODO [timestamp]`
instead of incrementing the timestamp itself. So I added a new regex
which will look for a bracket pair inside a string no matter if it's
surrounded or not.