### PR TITLE
Fix version mismatch preventing prepublish script execution in vsce package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "vscode-test": "^1.6.1"
             },
             "engines": {
-                "vscode": "^1.23.0"
+                "vscode": "^1.87.0"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "icon": "images/logo.png",
     "engines": {
-        "vscode": "^1.23.0"
+        "vscode": "^1.87.0"
     },
     "categories": [
         "Languages"


### PR DESCRIPTION
## Summary

Update `engines.vscode` to `^1.87.0` to match the `@types/vscode` version. This resolves the version mismatch error and allows `vsce package` to proceed past the initial validation.

## Problem

`vsce package` fails when the `@types/vscode` version is greater than `engines.vscode`.  

```shell
$ vsce package                
ERROR  @types/vscode ^1.87.0 greater than engines.vscode ^1.23.0. Either upgrade engines.vscode or use an older @types/vscode version
```

Previously we had `engines.vscode` at `^1.23.0` and `@types/vscode` at `^1.87.0`, which triggered this version mismatch and prevented the packaging process from even reaching the prepublish script.

## Solution

This change sets `engines.vscode` to `^1.87.0`, aligning it with `@types/vscode`.  
By resolving the version mismatch, `vsce package` can now proceed to execute the prepublish script (`npm run vscode:prepublish`).  

> [!NOTE]
> While this change raises the minimum supported VS Code version from `^1.23.0` ([released April 2018](https://code.visualstudio.com/updates/v1_23)) to `^1.87.0` ([released February 2024](https://code.visualstudio.com/updates/v1_87)), supporting VS Code versions from February 2024 onwards provides a reasonable support window for users. The six-year gap between these versions means that users on very old VS Code installations would need to update regardless.

After this fix, the packaging process advances further but then hits a separate issue—SVG images in README.md are restricted by the Marketplace:

```shell
$ vsce package
Executing prepublish script 'npm run vscode:prepublish'...

> org-mode@1.1.0-SNAPSHOT vscode:prepublish
> tsc -p ./

 ERROR  SVGs are restricted in README.md; please use other file image formats, such as PNG: https://vsmarketplacebadge.apphb.com/version/vscode-org-mode.org-mode.svg
```

This SVG restriction issue is out of scope for this PR and will be addressed separately.